### PR TITLE
setup CI to deploy login app for bmgfki

### DIFF
--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -5,6 +5,8 @@ branch-defaults:
     environment: synapse-login-scipoolprod
   strides:
     environment: synapse-login-strides
+  bmgfki:
+    environment: synapse-login-bmgfki
 global:
   application_name: synapse-login
   workspace_type: Application

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,11 @@ jobs:
         - echo -e "[default]\nregion=us-east-1\naws_access_key_id=$AwsTravisAccessKey_strides\naws_secret_access_key=$AwsTravisSecretAccessKey_strides" > ~/.aws/credentials
         - mvn clean package
         - travis-wait-improved --timeout 30m eb deploy synapse-login-strides --profile default --region us-east-1 --verbose
+    - stage: deploy-prod
+      name: "org-sagebase-bmgfki"
+      script:
+        - mkdir -p ~/.aws
+        - echo -e "[default]\nregion=us-east-1\nsource_profile=default\nrole_arn=$AwsCfServiceRoleArn_bmgfki" > ~/.aws/config
+        - echo -e "[default]\nregion=us-east-1\naws_access_key_id=$AwsTravisAccessKey_bmgfki\naws_secret_access_key=$AwsTravisSecretAccessKey_bmgfki" > ~/.aws/credentials
+        - mvn clean package
+        - travis-wait-improved --timeout 30m eb deploy synapse-login-bmgfki --profile default --region us-east-1 --verbose


### PR DESCRIPTION
Deploy a login app to bmgfki account to setup the Synapse IDP for the
service catalog.

depends on https://github.com/Sage-Bionetworks/synapse-login-aws-infra/pull/66