### PR TITLE
[SC-392] Update beanstalk solution stack for login app

### DIFF
--- a/.ebextensions/tomcatlogs.config
+++ b/.ebextensions/tomcatlogs.config
@@ -15,16 +15,19 @@
 ###################################################################################################
 
 files:
-  "/etc/awslogs/config/tomcatlogs.conf" :
-    mode: "000644"
-    owner: root
-    group: root
-    content: |
-      [/var/log/tomcat8/catalina.out]
-      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", {"Ref":"AWS::StackName"}, "var/log/tomcat8/catalina.out"]]}`
-      log_stream_name={instance_id}
-      file=/var/log/tomcat8/catalina.out*
-
+    "/etc/rsyslog.d/catalina.conf":
+        mode: "0655"
+        owner: root
+        group: root
+        content: |
+            #redirect tomcat logs to /var/log/tomcat/catalina.out discarding timestamps since the messages already have them
+            #https://stackoverflow.com/questions/64371139/missing-tomcat-logs-catalina-out-after-beanstalk-upgrade-to-64bit-amazon-linu
+            template(name="catalinalog" type="string"
+                string="%msg%\n")
+            if $programname  == 'server' then {
+              *.=warning;*.=err;*.=crit;*.=alert;*.=emerg /var/log/tomcat/catalina.out;catalinalog
+              *.=info;*.=notice /var/log/tomcat/catalina.out;catalinalog
+             }
 commands:
-  "01_restart_awslogs":
-    command: service awslogs restart
+    restart_rsyslog:
+        command: systemctl restart rsyslog

--- a/.ebextensions/tomcatlogs.config
+++ b/.ebextensions/tomcatlogs.config
@@ -14,7 +14,7 @@
 #### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
 ###################################################################################################
 
-files:
+  files:
     "/etc/rsyslog.d/catalina.conf":
         mode: "0655"
         owner: root
@@ -28,6 +28,8 @@ files:
               *.=warning;*.=err;*.=crit;*.=alert;*.=emerg /var/log/tomcat/catalina.out;catalinalog
               *.=info;*.=notice /var/log/tomcat/catalina.out;catalinalog
              }
-commands:
-    restart_rsyslog:
+
+
+  commands:
+    "01_restart_rsyslog":
         command: systemctl restart rsyslog

--- a/.ebextensions/tomcatlogs.config
+++ b/.ebextensions/tomcatlogs.config
@@ -14,22 +14,22 @@
 #### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
 ###################################################################################################
 
-  files:
-    "/etc/rsyslog.d/catalina.conf":
-        mode: "0655"
-        owner: root
-        group: root
-        content: |
-            #redirect tomcat logs to /var/log/tomcat/catalina.out discarding timestamps since the messages already have them
-            #https://stackoverflow.com/questions/64371139/missing-tomcat-logs-catalina-out-after-beanstalk-upgrade-to-64bit-amazon-linu
-            template(name="catalinalog" type="string"
-                string="%msg%\n")
-            if $programname  == 'server' then {
-              *.=warning;*.=err;*.=crit;*.=alert;*.=emerg /var/log/tomcat/catalina.out;catalinalog
-              *.=info;*.=notice /var/log/tomcat/catalina.out;catalinalog
-             }
+files:
+  "/etc/rsyslog.d/catalina.conf":
+    mode: "0655"
+    owner: root
+    group: root
+    content: |
+      #redirect tomcat logs to /var/log/tomcat/catalina.out discarding timestamps since the messages already have them
+      #https://stackoverflow.com/questions/64371139/missing-tomcat-logs-catalina-out-after-beanstalk-upgrade-to-64bit-amazon-linu
+      template(name="catalinalog" type="string"
+          string="%msg%\n")
+      if $programname  == 'server' then {
+        *.=warning;*.=err;*.=crit;*.=alert;*.=emerg /var/log/tomcat/catalina.out;catalinalog
+        *.=info;*.=notice /var/log/tomcat/catalina.out;catalinalog
+      }
 
 
-  commands:
-    "01_restart_rsyslog":
-        command: systemctl restart rsyslog
+commands:
+  "01_restart_rsyslog":
+    command: systemctl restart rsyslog


### PR DESCRIPTION
We are updating the solution stack to 64bit Amazon Linux 2 v4.2.18 running Tomcat 8.5 Corretto 8.  For the update to work we need to update the tomcat logs location.  We are using suggestion from stackoverflow[1].  That suggestion was used by Bridge apps and seems to work.

[1] https://stackoverflow.com/questions/64371139/missing-tomcat-logs-catalina-out-after-beanstalk-upgrade-to-64bit-amazon-linu

